### PR TITLE
chore: separate public parser and internal parser

### DIFF
--- a/handlers/parser.handler.go
+++ b/handlers/parser.handler.go
@@ -1,0 +1,26 @@
+package handlers
+
+import (
+	"resqiar.com-server/services"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+type ParserHandler interface {
+	ParseMDtoHTML(c *fiber.Ctx) error
+}
+
+type ParserHandlerImpl struct {
+	ParserService services.ParserService
+}
+
+func (s *ParserHandlerImpl) ParseMDtoHTML(c *fiber.Ctx) error {
+	payload := c.Body()
+	parsed := s.ParserService.ParseMDByte(payload)
+	if parsed == nil {
+		return c.SendStatus(fiber.StatusBadRequest)
+	}
+
+	c.Type("application/octet-stream")
+	return c.Status(fiber.StatusOK).Send(parsed)
+}

--- a/libs/module-init.lib.go
+++ b/libs/module-init.lib.go
@@ -23,6 +23,7 @@ func ModuleInit(server *fiber.App, DB *gorm.DB) {
 	}
 	blogService := services.BlogServiceImpl{UtilService: utilService, Repository: blogRepository}
 	authService := services.AuthServiceImpl{}
+	parserService := services.ParserServiceImpl{}
 
 	// Init handlers
 	authHandler := handlers.AuthHandlerImpl{
@@ -38,9 +39,13 @@ func ModuleInit(server *fiber.App, DB *gorm.DB) {
 		BlogService: &blogService,
 		UtilService: utilService,
 	}
+	parserHandler := handlers.ParserHandlerImpl{
+		ParserService: &parserService,
+	}
 
 	// Init routes
 	routes.InitAuthRoute(server, &authHandler)
 	routes.InitUserRoute(server, &userHandler)
 	routes.InitBlogRoute(server, &blogHandler)
+	routes.InitParserRoute(server, &parserHandler)
 }

--- a/routes/parser.route.go
+++ b/routes/parser.route.go
@@ -1,0 +1,12 @@
+package routes
+
+import (
+	"resqiar.com-server/handlers"
+
+	"github.com/gofiber/fiber/v2"
+)
+
+func InitParserRoute(server *fiber.App, handler handlers.ParserHandler) {
+	parser := server.Group("/parser")
+	parser.Post("/html", handler.ParseMDtoHTML)
+}

--- a/services/parser.service.go
+++ b/services/parser.service.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"bytes"
+	"log"
+	"sync"
+
+	chromahtml "github.com/alecthomas/chroma/v2/formatters/html"
+	"github.com/microcosm-cc/bluemonday"
+	"github.com/yuin/goldmark"
+	highlighting "github.com/yuin/goldmark-highlighting/v2"
+	"github.com/yuin/goldmark/extension"
+	"github.com/yuin/goldmark/parser"
+	html "github.com/yuin/goldmark/renderer/html"
+	"go.abhg.dev/goldmark/anchor"
+)
+
+var (
+	parserEngine = goldmark.New(
+		goldmark.WithExtensions(
+			extension.GFM,
+			highlighting.NewHighlighting(
+				highlighting.WithStyle("paraiso-dark"),
+				highlighting.WithFormatOptions(
+					chromahtml.WithLineNumbers(true),
+				),
+			),
+			&anchor.Extender{
+				Texter:   anchor.Text("#"),
+				Position: anchor.After,
+			},
+		),
+		goldmark.WithParserOptions(
+			parser.WithAutoHeadingID(),
+		),
+		goldmark.WithRendererOptions(
+			html.WithHardWraps(),
+			html.WithUnsafe(),
+		),
+	)
+	parserSanitization = bluemonday.UGCPolicy().AllowAttrs("style").OnElements("p", "span", "pre")
+	bufferPool         = sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+)
+
+type ParserService interface {
+	ParseMDByte(s []byte) []byte
+}
+
+type ParserServiceImpl struct{}
+
+func InitParserService() ParserService {
+	return &ParserServiceImpl{}
+}
+
+func (service *ParserServiceImpl) ParseMDByte(s []byte) []byte {
+	// use buffer from the Pool
+	buf := bufferPool.Get().(*bytes.Buffer)
+
+	// restore resources back to the pool when done
+	defer bufferPool.Put(buf)
+
+	// since we are reusing resources, better reset it first
+	buf.Reset()
+
+	if err := parserEngine.Convert(s, buf); err != nil {
+		log.Println("Error parsing MD:", err)
+		return nil
+	}
+
+	return parserSanitization.SanitizeBytes(buf.Bytes())
+}

--- a/services/parser_test.go
+++ b/services/parser_test.go
@@ -1,0 +1,57 @@
+package services
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var parserService = ParserServiceImpl{}
+
+func TestParseMDByte(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"hello paragraph", "<p>hello paragraph</p>\n"},
+		{"# Hello World", "<h1 id=\"hello-world\">Hello World <a href=\"#hello-world\" rel=\"nofollow\">#</a></h1>\n"},
+		{"## Hello World", "<h2 id=\"hello-world\">Hello World <a href=\"#hello-world\" rel=\"nofollow\">#</a></h2>\n"},
+		{"### Hello World", "<h3 id=\"hello-world\">Hello World <a href=\"#hello-world\" rel=\"nofollow\">#</a></h3>\n"},
+		{"#### Hello World", "<h4 id=\"hello-world\">Hello World <a href=\"#hello-world\" rel=\"nofollow\">#</a></h4>\n"},
+		{"##### Hello World", "<h5 id=\"hello-world\">Hello World <a href=\"#hello-world\" rel=\"nofollow\">#</a></h5>\n"},
+		{"###### Hello World", "<h6 id=\"hello-world\">Hello World <a href=\"#hello-world\" rel=\"nofollow\">#</a></h6>\n"},
+		{"* Item 1\n* Item 2", "<ul>\n<li>Item 1</li>\n<li>Item 2</li>\n</ul>\n"},
+		{"> Blockquote", "<blockquote>\n<p>Blockquote</p>\n</blockquote>\n"},
+		{"[Link](https://www.example.com)", "<p><a href=\"https://www.example.com\" rel=\"nofollow\">Link</a></p>\n"},
+		{"**Bold Text**", "<p><strong>Bold Text</strong></p>\n"},
+		{"*Italic Text*", "<p><em>Italic Text</em></p>\n"},
+		{"`Code Snippet`", "<p><code>Code Snippet</code></p>\n"},
+		{"1. Item 1\n2. Item 2", "<ol>\n<li>Item 1</li>\n<li>Item 2</li>\n</ol>\n"},
+		{"![Image](https://www.example.com/image.jpg)", "<p><img src=\"https://www.example.com/image.jpg\" alt=\"Image\"></p>\n"},
+
+		{"<script>alert('XSS Attack');</script>", ""},
+		{"<img src=\"x\" onerror=\"alert('XSS Attack')\">", "<img src=\"x\">"},
+		{"<a href=\"javascript:alert('XSS Attack')\">Click Me</a>", "<p>Click Me</p>\n"},
+		{"<p onmouseover=alert(\"XSS Attack!\")>click me!</p>", "<p>click me!</p>"},
+		{"<img src=\"https://url.to.file.which/not.exist\" onerror=alert(document.cookie);/>", "<img src=\"https://url.to.file.which/not.exist\"/>"},
+		{"<img src=j&#X41vascript:alert(\"XSS Attack\")/>", "<p>&lt;img src=j&amp;#X41vascript:alert(&#34;XSS Attack&#34;)/&gt;</p>\n"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("Should parse MD from: %s TO %s", tc.input, tc.expected), func(t *testing.T) {
+			generated := parserService.ParseMDByte([]byte(tc.input))
+
+			if tc.expected == "" {
+				require.Empty(t, generated)
+			} else {
+				// if the value is Empty (Nil / empty string), then stop the test
+				require.NotEmpty(t, generated)
+
+				// assert if the value is as expected
+				assert.Equal(t, []byte(tc.expected), generated)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Just as it names suggest, it adds a new route, handler, and service for public markdown transformation. Practically will be used in parser.resqiar.com